### PR TITLE
Add a note to the docs that the first line of a password file is assumed to be the password

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ an easy flow for updating passwords. It supports path, directory and wildcard
 update. Moreover, you can select how to update your passwords by automatically
 generating new passwords or manually setting your own.
 
+`pass update` assumes that the first line of the password file is the password
+and so only ever updates the first line unless the `--multiline` option is
+specified.
+
 By default, `pass update` prints the old password and waits for the user before
 generating a new one. This behaviour can be changed using the provided options.
 
@@ -40,6 +44,9 @@ Usage:
 
             It prints the old password and waits for the user before generating
             a new one. This behaviour can be changed using the provided options.
+
+            Only the first line of a password file is updated unless the
+            --multiline opiton is specified.
 
     	Options:
             -c, --clip       Write the password to the clipboard.

--- a/pass-update.1
+++ b/pass-update.1
@@ -13,6 +13,10 @@ an easy flow for updating passwords. It supports path, directory and wildcard
 update. Moreover, you can select how to update your passwords by automatically
 generating new passwords or manually setting your own.
 
+\fBpass update\fP assumes that the first line of the password file is the
+password and so only ever updates the first line unless the \fI--multiline\fP
+option is specified.
+
 By default \fBpass update\fP prints the old password and wait for the user before
 generating a new one. This behaviour can be changed using the provided options.
 

--- a/update.bash
+++ b/update.bash
@@ -42,6 +42,9 @@ cmd_update_usage() {
             It prints the old password and waits for the user before generating
             a new one. This behaviour can be changed using the provided options.
 
+            Only the first line of a password file is updated unless the
+            --multiline opiton is specified.
+
     	Options:
             -c, --clip       Write the password to the clipboard.
             -n, --no-symbols Do not use any non-alphanumeric characters.


### PR DESCRIPTION
This addresses the issue I raised (roddhjav/pass-update#18) by adding note to the README file, the man page and the usage message.